### PR TITLE
Fix: [ PIZ1 ] - can't create order

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,10 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+@size.route('/', methods=GET)
+def get_sizes():
+    sizes, error = SizeController.get_all()
+    response = sizes if not error else {'error': error}
+    status_code = 200 if sizes else 404 if not error else 400
+    return jsonify(response), status_code


### PR DESCRIPTION
**Fixes from the ticket**: [PIZ1 - I can't create an order](https://trello.com/c/VLQqeuPm)

**Description**:

The fix for this bug was kind of easy, the order was not being created because of missing get_sizes() function. Thus, the order wasn't able to bring the sizes, needed for creating the order. I added this and now works perfectly.
![image](https://github.com/user-attachments/assets/2dab3915-5bcc-4219-9185-9cffd6985581)


All the tests passing :heavy_check_mark:.